### PR TITLE
[BREAKING-CHANGES: Bug date field]: fix(session) #MCDT-560: remove to_date() psql #Jira - MCDT-560

### DIFF
--- a/src/main/java/fr/openent/diary/utils/DateUtils.java
+++ b/src/main/java/fr/openent/diary/utils/DateUtils.java
@@ -101,6 +101,7 @@ public final class DateUtils {
     }
 
     public static String formatDate(Date dateToParse, String format) {
+        if (dateToParse == null) return null;
         SimpleDateFormat dateFormat = new SimpleDateFormat(format);
         return dateFormat.format(dateToParse);
     }


### PR DESCRIPTION
[Jira - MCDT-560](https://entsupport.gdapublic.fr/secure/RapidBoard.jspa?rapidView=36&projectKey=MCDT&view=detail&selectedIssue=MCDT-560)

Ce ticket est survenu à la suite d'un bug récurent en production:
De temps en temps, lorsqu'un enseignant enregistre une sessions à partir d'un cours, la date de cette dernière se change au jour d'avant.

Pour enquêter et savoir à quel moment du processus de création le problème survient, nous avons demandé à ODE la trace en PROD concernant la création d'une session sur laquelle le bug est survenu.
Voici le résultat:
![image](https://user-images.githubusercontent.com/55873580/133614756-0cb6851e-667f-4733-9f08-0498c147f09f.png)
Ici l'enseignant souhaiter créer une séance à partir d'un cours survenant le 14/09/2021. 
Le problème observé est qu'une fois enregistré, la date de la session est le 13/09/2021.
On remarque que le champ "date" (le champ qui nous intéresse) contenu par le payload reçu du client est valide.
En conclusion, l'erreur survient côté serveur.

Après analyse du script en backend, le seul traitement "particulier" appliqué sur le champ date se trouve au niveau de la requête postgresql: 
![image](https://user-images.githubusercontent.com/55873580/133616284-c8ff75ce-0862-4689-ab00-261176730f40.png)
La tentative de résolution de ce ticket est donc de supprimer l'utilisation de cette méthode "to_date()", afin d'éviter les traitements que nous ne maitrisons pas.
Un traitement a donc été ajouté en java (traitement que nous contrôlons) pour forcer le format de la date à yyyy-MM-dd      