### PR TITLE
fix(session/homework) #MCDT-561: Allow students to view sessions / ho…

### DIFF
--- a/src/main/resources/public/ts/app.ts
+++ b/src/main/resources/public/ts/app.ts
@@ -44,18 +44,22 @@ routes.define(($routeProvider) => {
             })
             .when('/session/update/:id', {
                 action: 'manageSession'
+            });
+    }
+
+    if (model.me.hasWorkflow(Behaviours.applicationsBehaviours.diary.rights.workflow.manageHomework)) {
+        $routeProvider
+            .when('/homework/create', {
+                action: 'manageHomework'
             })
-            .when('/session/view/:id', {
-                action: 'manageSession'
+            .when('/homework/update/:id', {
+                action: 'manageHomework'
             });
     }
 
     $routeProvider
-        .when('/homework/create', {
-            action: 'manageHomework'
-        })
-        .when('/homework/update/:id', {
-            action: 'manageHomework'
+        .when('/session/view/:id', {
+            action: 'manageSession'
         })
         .when('/homework/view/:id', {
             action: 'manageHomework'


### PR DESCRIPTION
[Jira - MCDT-561](https://entsupport.gdapublic.fr/secure/RapidBoard.jspa?rapidView=36&projectKey=MCDT&view=detail&selectedIssue=MCDT-558)
Dans le fichier app.ts, au niveau de la définition des routes dans le $routeProvider, on retrouve un bloque de route accessible que lorsque l'utilisateur actuel possède le droit "manageSession".
Le problème étant que la route "view" était avant ce ticket régit par ce même droit, et qu'un étudiant ne possède pas se droit (et ne peut donc plus voir les sessions qui le concerne).

Il suffisait donc de retirer le groupe de cette logique.
La même gestion concernant le CRUD des "Homeworks" (avec le droit "manageHomework") a été ajouté.  