### PR TITLE
feat(search) #MCDT-566: search for multiple audiences at the same time.

### DIFF
--- a/src/main/java/fr/openent/diary/controllers/HomeworkController.java
+++ b/src/main/java/fr/openent/diary/controllers/HomeworkController.java
@@ -18,6 +18,8 @@ import org.entcore.common.http.filter.Trace;
 import org.entcore.common.http.response.DefaultResponseHandler;
 import org.entcore.common.user.UserUtils;
 
+import java.util.List;
+
 public class HomeworkController extends ControllerHelper {
 
     private HomeworkService homeworkService;
@@ -66,10 +68,10 @@ public class HomeworkController extends ControllerHelper {
         String startDate = request.getParam("startDate");
         String endDate = request.getParam("endDate");
         String teacherId = request.getParam("teacherId");
-        String audienceId = request.getParam("audienceId");
+        List<String> audienceIds = request.params().getAll("audienceId");
         String subjectId = request.getParam("subjectId");
 
-        homeworkService.getExternalHomeworks(startDate, endDate, teacherId, audienceId, subjectId, DefaultResponseHandler.arrayResponseHandler(request));
+        homeworkService.getExternalHomeworks(startDate, endDate, teacherId, audienceIds, subjectId, DefaultResponseHandler.arrayResponseHandler(request));
     }
 
     @Get("/homeworks/child/:startDate/:endDate/:childId/:structureId")

--- a/src/main/java/fr/openent/diary/controllers/SessionController.java
+++ b/src/main/java/fr/openent/diary/controllers/SessionController.java
@@ -69,11 +69,11 @@ public class SessionController extends ControllerHelper {
     public void getExternalSessions(final HttpServerRequest request) {
         String startDate = request.getParam("startDate");
         String endDate = request.getParam("endDate");
-        String audienceId = request.getParam("audienceId");
+        List<String> audienceIds = request.params().getAll("audienceId");
         String teacherId = request.getParam("teacherId");
         String subjectId = request.getParam("subjectId");
 
-        sessionService.getExternalSessions(startDate, endDate, teacherId, audienceId, subjectId, DefaultResponseHandler.arrayResponseHandler(request));
+        sessionService.getExternalSessions(startDate, endDate, teacherId, audienceIds, subjectId, DefaultResponseHandler.arrayResponseHandler(request));
     }
 
     @Get("/sessions/child/:startDate/:endDate/:childId")

--- a/src/main/java/fr/openent/diary/services/HomeworkService.java
+++ b/src/main/java/fr/openent/diary/services/HomeworkService.java
@@ -6,6 +6,8 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.user.UserInfos;
 
+import java.util.List;
+
 public interface HomeworkService {
 
     void getHomework(long homeworkId, UserInfos user, Handler<Either<String, JsonObject>> handler);
@@ -13,7 +15,7 @@ public interface HomeworkService {
     void getOwnHomeworks(String structureId,String startDate, String endDate, UserInfos user, String subjectId,
                          String teacherId, String audienceId, Handler<Either<String, JsonArray>> handler);
 
-    void getExternalHomeworks( String startDate, String endDate, String teacherId, String audienceId, String subjectId, Handler<Either<String, JsonArray>> handler);
+    void getExternalHomeworks(String startDate, String endDate, String teacherId, List<String> audienceIds, String subjectId, Handler<Either<String, JsonArray>> handler);
 
     void getChildHomeworks(String structureId, String startDate, String endDate, String childId, String subjectId, Handler<Either<String, JsonArray>> handler);
 

--- a/src/main/java/fr/openent/diary/services/SessionService.java
+++ b/src/main/java/fr/openent/diary/services/SessionService.java
@@ -14,7 +14,7 @@ public interface SessionService {
 
     void getOwnSessions(String structureId, String startDate, String endDate, List<String> audienceIds, String subjectId, UserInfos user, Handler<Either<String, JsonArray>> handler);
 
-    void getExternalSessions(String startDate, String endDate, String teacherId, String audienceId, String subjectId, Handler<Either<String, JsonArray>> handler);
+    void getExternalSessions(String startDate, String endDate, String teacherId, List<String> audienceIds, String subjectId, Handler<Either<String, JsonArray>> handler);
 
     void getChildSessions(String structureId, String startDate, String endDate, String childId, List<String> listSubjectId, Handler<Either<String, JsonArray>> handler);
 

--- a/src/main/java/fr/openent/diary/services/impl/HomeworkServiceImpl.java
+++ b/src/main/java/fr/openent/diary/services/impl/HomeworkServiceImpl.java
@@ -105,8 +105,8 @@ public class HomeworkServiceImpl extends SqlCrudService implements HomeworkServi
     }
 
     @Override
-    public void getExternalHomeworks(String startDate, String endDate, String teacherId, String audienceId, String subjectId, Handler<Either<String, JsonArray>> handler) {
-        List<String> listAudienceId = audienceId != null && !audienceId.equals("") ? Arrays.asList(audienceId) : null;
+    public void getExternalHomeworks(String startDate, String endDate, String teacherId, List<String> audienceIds, String subjectId, Handler<Either<String, JsonArray>> handler) {
+        List<String> listAudienceId = audienceIds != null && !audienceIds.isEmpty() ? audienceIds : null;
         List<String> listTeacherId = teacherId != null && !teacherId.equals("") ? Arrays.asList(teacherId) : null;
 
         this.getHomeworks("", startDate, endDate, null, listAudienceId, listTeacherId, subjectId, true, handler);

--- a/src/main/java/fr/openent/diary/services/impl/SessionServiceImpl.java
+++ b/src/main/java/fr/openent/diary/services/impl/SessionServiceImpl.java
@@ -184,8 +184,8 @@ public class SessionServiceImpl extends DBService implements SessionService {
     }
 
     @Override
-    public void getExternalSessions(String startDate, String endDate, String teacherId, String audienceId, String subjectId, Handler<Either<String, JsonArray>> handler) {
-        List<String> listAudienceId = audienceId != null && !audienceId.equals("") ? Arrays.asList(audienceId) : null;
+    public void getExternalSessions(String startDate, String endDate, String teacherId, List<String> audienceIds, String subjectId, Handler<Either<String, JsonArray>> handler) {
+        List<String> listAudienceId = audienceIds != null && !audienceIds.isEmpty() ? audienceIds : null;
         List<String> listTeacherId = teacherId != null && !teacherId.equals("") ? Arrays.asList(teacherId) : null;
         List<String> listSubjectId = subjectId != null ? Arrays.asList(subjectId) : null;
 

--- a/src/main/resources/public/sass/global/components/_administrator-page.scss
+++ b/src/main/resources/public/sass/global/components/_administrator-page.scss
@@ -240,6 +240,7 @@
 .administrator-page-list {
   display: flex;
   flex-flow: wrap;
+  height: 60px;
   &-item {
     display: inline;
     margin: 0 5px;

--- a/src/main/resources/public/sass/global/components/_main.scss
+++ b/src/main/resources/public/sass/global/components/_main.scss
@@ -430,6 +430,9 @@ ul.search-input-ul {
   margin: 0;
   font-weight: bold;
   list-style-type: none;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
 }
 
 label.checkbox {

--- a/src/main/resources/public/sass/global/components/main/_sidebar.scss
+++ b/src/main/resources/public/sass/global/components/main/_sidebar.scss
@@ -4,5 +4,18 @@
       padding-left: 16px;
       padding-right: 16px;
     }
+
+    .progression-container {
+      max-height: 32vh;
+    }
+
+    .audiences-container {
+      max-height: 12vh;
+      overflow: auto;
+
+      ul {
+        list-style-type: none;
+      }
+    }
   }
 }

--- a/src/main/resources/public/template/administrator/admin-main-page.html
+++ b/src/main/resources/public/template/administrator/admin-main-page.html
@@ -39,12 +39,12 @@
             <div class="flex-col col__6">
                 <div class="search-input">
                     <async-autocomplete data-ng-disabled="false"
-                                        data-ng-model="groupsSearch.group"
-                                        data-ng-change="selectGroup"
-                                        data-on-search="searchGroup"
-                                        data-options="groupsSearch.groups"
+                                        data-ng-model="audiencesSearch.searchQuery"
+                                        data-ng-change="selectAudience"
+                                        data-on-search="searchAudience"
+                                        data-options="audiencesSearch.searchItems"
                                         data-placeholder="diary.search.group"
-                                        data-search="groupsSearch.group">
+                                        data-search="audiencesSearch.searchQuery">
                     </async-autocomplete>
                 </div>
             </div>
@@ -54,7 +54,7 @@
     <!-- Result teacher/classes from async autocomplete -->
     <div class="flex-row-cdt row__12 list-search">
         <div class="flex-col col__3 list-search"></div>
-        <div class="flex-col col__9 list-search">
+        <div class="flex-col col__9">
             <div class="flex-col col__6 list-search">
                 <!-- Teacher selected via filter -->
                 <div class="cell twelve administrator-page-list">
@@ -70,8 +70,8 @@
                 <!-- Class selected via filter -->
                 <div class="cell twelve administrator-page-list">
                     <ul class="cell twelve search-input-ul">
-                        <li ng-repeat="group in groupsSearch.selectedGroups" class="administrator-page-list-item">
-                            [[group.toString()]] <i class="close" data-ng-click="removeSelectedGroups(class)"></i>
+                        <li ng-repeat="audience in audiencesSearch.selectedAudiences" class="administrator-page-list-item">
+                            [[audience.toString()]] <i class="close" data-ng-click="removeSelectedAudience(audience)"></i>
                         </li>
                     </ul>
                 </div>

--- a/src/main/resources/public/template/list/list-view-header.html
+++ b/src/main/resources/public/template/list/list-view-header.html
@@ -48,14 +48,5 @@
                                 data-search="autocomplete.class">
             </async-autocomplete>
         </div>
-        <div class="cell twelve main-header-result-search"
-             ng-show="autocomplete.classesSelected[0] && autocomplete.classesSelected[0].displayName !== ''">
-            <ul class="cell twelve search-input-ul">
-                <li>
-                    [[autocomplete.classesSelected[0].displayName]]
-                    <i class="close" data-ng-click="removeClass(autocomplete.classesSelected[0])"></i>
-                </li>
-            </ul>
-        </div>
     </div>
 </div>

--- a/src/main/resources/public/template/list/list-view.html
+++ b/src/main/resources/public/template/list/list-view.html
@@ -12,6 +12,8 @@
                     structures="structures"
                     is-homeworks-filtered="display.homeworks"
                     is-sessions-filtered="display.sessionList"
+                    audiences="autocomplete.classesSelected"
+                    on-remove-audience="setClasses"
                     class="cell three twelve-mobile sidebar-content">
     </sidebar-filter>
 

--- a/src/main/resources/public/template/main.html
+++ b/src/main/resources/public/template/main.html
@@ -50,15 +50,6 @@
                                     data-search="autocomplete.class">
                 </async-autocomplete>
             </div>
-            <div class="cell twelve main-header-result-search"
-                 ng-show="autocomplete.classesSelected[0] && autocomplete.classesSelected[0].displayName !== ''">
-                <ul class="cell twelve search-input-ul">
-                    <li>
-                        [[autocomplete.classesSelected[0].displayName]]
-                        <i class="close" data-ng-click="removeClass(autocomplete.classesSelected[0])"></i>
-                    </li>
-                </ul>
-            </div>
         </div>
 
         <!-- button interact mode -->
@@ -84,11 +75,12 @@
                         structures="structures"
                         is-homeworks-filtered="display.homeworks"
                         is-sessions-filtered="display.sessionList"
+                        audiences="autocomplete.classesSelected"
+                        on-remove-audience="setClasses"
                         class="cell three twelve-mobile sidebar-content">
         </sidebar-filter>
 
-        <div class="cell twelve-mobile main-content" ng-if="!display.listView"
-             ng-class="(isAChildOrAParent || isTeacher) ? 'nine' : 'twelve'"
+        <div class="cell twelve-mobile main-content nine" ng-if="!display.listView"
              ng-include="'/diary/public/template/main/calendar-view.html'">
         </div>
     </div>

--- a/src/main/resources/public/ts/directives/sidebar-filter/sidebar-filter.html
+++ b/src/main/resources/public/ts/directives/sidebar-filter/sidebar-filter.html
@@ -1,26 +1,22 @@
-<article class="sidebar remove-padding" workflow="diary.listView">
+<article class="sidebar sidebar-article remove-padding">
+    <!-- SELECT STRUCTURE -->
+    <select-structure ng-if="vm.userUtils.amIStudentOrParent()" structure="vm.structure"></select-structure>
 
-    <div>
-        <!-- SELECT STRUCTURE -->
-        <select-structure ng-if="vm.userUtils.amIStudentOrParent()" structure="vm.structure"></select-structure>
+    <!-- Display mode -->
+    <div ng-if="!vm.mobileUtils.isMobile()" class="row title-sidebar padding-left-md padding-right-md">
+        <h5 class="large cell twelve" workflow="diary.listView">
+            <i18n>sidebar.display_mode</i18n>
+            <!-- Legend -->
+            <i class="large help one cell right-magnet" ng-if="vm.areShownViews[vm.SIDEBAR_VIEWS.CALENDAR]"
+               tooltip="[[vm.lang.translate('help')]]" ng-click="vm.setLegendVisibility(true)"></i>
+        </h5>
+    </div>
 
-        <!-- Display mode -->
-        <div ng-if="!vm.mobileUtils.isMobile()" class="row title-sidebar padding-left-md padding-right-md">
-            <h5 class="large cell twelve" workflow="diary.listView">
-                <i18n>sidebar.display_mode</i18n>
-                <!-- Legend -->
-                <i class="large help one cell right-magnet" ng-if="vm.areShownViews[vm.SIDEBAR_VIEWS.CALENDAR]"
-                   tooltip="[[vm.lang.translate('help')]]" ng-click="vm.setLegendVisibility(true)"></i>
-            </h5>
-        </div>
-
-        <!-- Bloc Mode d'affichage -->
-        <section ng-if="!vm.mobileUtils.isMobile()" id="display-section"
-                 class="cell twelve padding-left-md padding-bottom-sm padding-top-sm display-background">
-            <label workflow="diary.listView" class="cell twelve">
-
-                <!-- switch calendar mode -->
-                <span class="six diary-choice-view" data-ng-click="vm.changeView(vm.SIDEBAR_VIEWS.CALENDAR)">
+    <!-- Bloc Mode d'affichage -->
+    <section workflow="diary.listView" ng-if="!vm.mobileUtils.isMobile()" id="display-section"
+             class="cell twelve padding-left-md padding-bottom-sm padding-top-sm display-background">
+        <!-- switch calendar mode -->
+        <span class="six diary-choice-view" data-ng-click="vm.changeView(vm.SIDEBAR_VIEWS.CALENDAR)">
                     <div ng-include="'/diary/public/img/calendaire.svg'"
                          class="margin-sm cursorPointer"
                          ng-class="vm.areShownViews[vm.SIDEBAR_VIEWS.CALENDAR] ? 'selected' : 'opacity-icon'">
@@ -28,8 +24,8 @@
                     <i18n>calendar</i18n>
                 </span>
 
-                <!-- switch list mode -->
-                <span class="six diary-choice-view" data-ng-click="vm.changeView(vm.SIDEBAR_VIEWS.LIST)">
+        <!-- switch list mode -->
+        <span class="six diary-choice-view" data-ng-click="vm.changeView(vm.SIDEBAR_VIEWS.LIST)">
                     <div ng-include="'/diary/public/img/liste.svg'"
                          class="margin-sm cursorPointer"
                          ng-class="vm.areShownViews[vm.SIDEBAR_VIEWS.LIST] ? 'selected' : 'opacity-icon'"
@@ -37,104 +33,122 @@
                     </div>
                     <i18n>list</i18n>
                 </span>
-            </label>
-        </section>
+    </section>
 
-        <!-- children content as parent -->
-        <div class="row" ng-if="vm.userUtils.amIRelative()">
-            <div class="row title-sidebar padding-left-md padding-right-md"
-                 data-ng-click="vm.collapseMobile(vm.SIDEBAR_AREAS.CHILDREN)">
-                <h5 class="large cell twelve">
-                    <i18n>children</i18n>
-
-                    <i ng-show="vm.mobileUtils.isMobile()"
-                       ng-class="vm.areShownAreas[vm.SIDEBAR_AREAS.CHILDREN] ? 'up-open' : 'down-open'"
-                       class="right-magnet">
-                    </i>
-                </h5>
-            </div>
-            <div ng-if="vm.areShownAreas[vm.SIDEBAR_AREAS.CHILDREN]"
-                 ng-class="vm.areShownViews[vm.SIDEBAR_VIEWS.LIST] ? 'padding-md' : 'padding-right-md padding-left-md padding-top-md'">
-                <select data-ng-model="vm.child"
-                        class="twelve"
-                        data-ng-change="vm.changeStudent()"
-                        ng-options="child as child.displayName for child in vm.structures.getStudents() track by child.id">
-                    <option value="" disabled>[[vm.lang.translate('student.choose')]]</option>
-                </select>
-            </div>
-        </div>
-
-        <!-- Filter -->
+    <!-- children content as parent -->
+    <div class="row" ng-if="vm.userUtils.amIRelative()">
         <div class="row title-sidebar padding-left-md padding-right-md"
-             data-ng-click="vm.collapseMobile(vm.SIDEBAR_AREAS.FILTER)"
-             ng-if="vm.areShownViews[vm.SIDEBAR_VIEWS.LIST] && vm.userUtils.amIStudentOrParent()">
-            <h5 class="large cell twelve" workflow="diary.listView">
-                <i18n>filters</i18n>
+             data-ng-click="vm.collapseMobile(vm.SIDEBAR_AREAS.CHILDREN)">
+            <h5 class="large cell twelve">
+                <i18n>children</i18n>
 
                 <i ng-show="vm.mobileUtils.isMobile()"
-                   ng-class="vm.areShownAreas[vm.SIDEBAR_AREAS.FILTER] ? 'up-open' : 'down-open'"
+                   ng-class="vm.areShownAreas[vm.SIDEBAR_AREAS.CHILDREN] ? 'up-open' : 'down-open'"
                    class="right-magnet">
                 </i>
             </h5>
         </div>
-        <section ng-if="(vm.userUtils.amIStudentOrParent() || vm.userUtils.amITeacher()) && vm.areShownAreas[vm.SIDEBAR_AREAS.FILTER]"
-                 class="cell twelve padding-left-md margin-bottom-lg padding-bottom-sm padding-top-sm display-background">
-            <label workflow="diary.listView" class="cell twelve margin-bottom-md" ng-if="vm.areShownViews[vm.SIDEBAR_VIEWS.LIST]">
-                <!-- homework -->
-                <div class="six diary-choice-view">
-                    <label class="checkbox">
-                        <input type="checkbox" ng-model="vm.isHomeworksFiltered"/>
-                        <span><i18n>Homeworks</i18n></span>
-                    </label>
-                </div>
+        <div ng-if="vm.areShownAreas[vm.SIDEBAR_AREAS.CHILDREN]"
+             ng-class="vm.areShownViews[vm.SIDEBAR_VIEWS.LIST] ? 'padding-md' : 'padding-right-md padding-left-md padding-top-md'">
+            <select data-ng-model="vm.child"
+                    class="twelve"
+                    data-ng-change="vm.changeStudent()"
+                    ng-options="child as child.displayName for child in vm.structures.getStudents() track by child.id">
+                <option value="" disabled>[[vm.lang.translate('student.choose')]]</option>
+            </select>
+        </div>
+    </div>
 
-                <!-- session -->
-                <div class="six diary-choice-view">
-                    <label class="checkbox">
-                        <input type="checkbox" ng-model="vm.isSessionsFiltered"/>
-                        <span><i18n>sessions</i18n></span>
-                    </label>
-                </div>
-            </label>
+    <!-- Filter -->
+    <div class="row title-sidebar padding-left-md padding-right-md"
+         data-ng-click="vm.collapseMobile(vm.SIDEBAR_AREAS.FILTER)"
+         ng-if="vm.areShownViews[vm.SIDEBAR_VIEWS.LIST] && vm.userUtils.amIStudentOrParent()">
+        <h5 class="large cell twelve" workflow="diary.listView">
+            <i18n>filters</i18n>
 
-            <!-- FILTER STRUCTURE -->
-            <div class="padding-right-md" ng-if="vm.userUtils.amIStudentOrParent()">
-                <select ng-model="vm.structure"
-                        ng-show="vm.currentChildStructures().length > 1"
-                        class="twelve"
-                        ng-options="structure as structure.name for structure in vm.currentChildStructures() track by structure.id"
-                        ng-change="vm.changeStructure()">
-                    <option value="" disabled>[[vm.lang.translate('utils.structure.choose.one')]]</option>
-                </select>
+            <i ng-show="vm.mobileUtils.isMobile()"
+               ng-class="vm.areShownAreas[vm.SIDEBAR_AREAS.FILTER] ? 'up-open' : 'down-open'"
+               class="right-magnet">
+            </i>
+        </h5>
+    </div>
+    <section
+            ng-if="vm.areShownAreas[vm.SIDEBAR_AREAS.FILTER]"
+            class="cell twelve padding-left-md margin-bottom-lg padding-bottom-sm padding-top-sm display-background">
+        <label workflow="diary.listView" class="cell twelve margin-bottom-md"
+               ng-if="vm.areShownViews[vm.SIDEBAR_VIEWS.LIST]">
+            <!-- homework -->
+            <div class="six diary-choice-view">
+                <label class="checkbox">
+                    <input type="checkbox" ng-model="vm.isHomeworksFiltered"/>
+                    <span><i18n>Homeworks</i18n></span>
+                </label>
             </div>
 
-            <!-- SELECT SUBJECT -->
-            <filter-subject
-                    subjects="vm.subjects.all"
-                    current-subject="vm.subject" ng-if="vm.areShownViews[vm.SIDEBAR_VIEWS.LIST]">
-            </filter-subject>
+            <!-- session -->
+            <div class="six diary-choice-view">
+                <label class="checkbox">
+                    <input type="checkbox" ng-model="vm.isSessionsFiltered"/>
+                    <span><i18n>sessions</i18n></span>
+                </label>
+            </div>
+        </label>
+
+        <!-- FILTER STRUCTURE -->
+        <div class="padding-right-md" ng-if="vm.userUtils.amIStudentOrParent()">
+            <select ng-model="vm.structure"
+                    ng-show="vm.currentChildStructures().length > 1"
+                    class="twelve"
+                    ng-options="structure as structure.name for structure in vm.currentChildStructures() track by structure.id"
+                    ng-change="vm.changeStructure()">
+                <option value="" disabled>[[vm.lang.translate('utils.structure.choose.one')]]</option>
+            </select>
+        </div>
+
+        <!-- SELECT SUBJECT -->
+        <filter-subject
+                subjects="vm.subjects.all"
+                current-subject="vm.subject" ng-if="vm.areShownViews[vm.SIDEBAR_VIEWS.LIST]">
+        </filter-subject>
+    </section>
+
+    <!-- Progression -->
+    <div ng-if="vm.userUtils.amITeacher()" ng-show="vm.areShownViews[vm.SIDEBAR_VIEWS.CALENDAR]">
+        <div class="row title-sidebar padding-left-md padding-right-md">
+            <h5 class="large cell twelve">
+                <i18n>progressions</i18n>
+            </h5>
+        </div>
+        <!-- Bloc Progression -->
+        <section class="progression-container cell twelve padding-md" ng-controller="manageProgessionCtrl">
+            <div class="row">
+                <input ng-change="filterProgression(search)"
+                       class="progression-search remove-box-shadow cell twelve"
+                       type="text"
+                       ng-model="search"
+                       placeholder="Rechercher">
+                <div class="row margin-bottom-lg progression-tree"
+                     ng-include="'/diary/public/template/progression/progression-tree.html'">
+                </div>
+            </div>
         </section>
+    </div>
 
-        <!-- Progression -->
-        <div ng-if="vm.userUtils.amITeacher()" ng-show="vm.areShownViews[vm.SIDEBAR_VIEWS.CALENDAR]">
-            <div class="row title-sidebar padding-left-md padding-right-md">
-                <h5 class="large cell twelve">
-                    <i18n>progressions</i18n>
-                </h5>
-            </div>
-            <!-- Bloc Progression -->
-            <section class="progression-container cell twelve padding-md" ng-controller="manageProgessionCtrl">
-                <div class="row">
-                    <input ng-change="filterProgression(search)"
-                           class="progression-search remove-box-shadow cell twelve"
-                           type="text"
-                           ng-model="search"
-                           placeholder="Rechercher">
-                    <div class="row margin-bottom-lg progression-tree"
-                         ng-include="'/diary/public/template/progression/progression-tree.html'">
-                    </div>
-                </div>
-            </section>
+    <!-- Audiences -->
+    <div ng-if="!vm.userUtils.amIStudentOrParent() && vm.audiences.length > 0">
+        <div class="row title-sidebar padding-left-md padding-right-md">
+            <h5 class="large cell twelve">
+                <i18n>printer.audience</i18n>
+            </h5>
+        </div>
+        <!-- Bloc Audiences -->
+        <div class="cell twelve audiences-container display-background">
+            <ul class="cell twelve ">
+                <li ng-repeat="audience in vm.audiences">
+                    [[audience.name]]
+                    <i class="close" data-ng-click="vm.removeAudience(audience)"></i>
+                </li>
+            </ul>
         </div>
     </div>
 </article>

--- a/src/main/resources/public/ts/model/audience.ts
+++ b/src/main/resources/public/ts/model/audience.ts
@@ -1,6 +1,8 @@
-import { Mix } from 'entcore-toolkit';
+import {Mix} from 'entcore-toolkit';
 import http, {AxiosResponse} from 'axios';
 import {Student} from "./student";
+import {ArrayUtils} from "../utils/array.utils";
+import {Group, Groups} from "./group";
 
 export interface IAudience {
     id?: string;
@@ -77,11 +79,14 @@ export class Audiences {
     }
 
     add(audience: Audience): void {
-        if(!this.all.find((a: Audience) => a.id === audience.id)) this.all.push(audience);
+        if (!this.all.find((a: Audience) => a.id === audience.id)) this.all.push(audience);
     }
 
     getAudienceFromStudent = (student: Student): Audience =>
-        this.all.find((audience: Audience)  => audience.id === student.classId)
+        this.all.find((audience: Audience) => audience.id === student.classId)
+
+    getAudiencesFromGroups = (groups: Groups): Audience[] =>
+        this.all.filter((audience: Audience) => groups.getIds().indexOf(audience.id) != -1);
 
     getAudiences = (audienceNames: string[]): Audience[] =>
         this.all.filter((audience: Audience) =>

--- a/src/main/resources/public/ts/model/group.ts
+++ b/src/main/resources/public/ts/model/group.ts
@@ -1,5 +1,6 @@
 import http from "axios";
 import {Student} from "./student";
+import {ArrayUtils} from "../utils/array.utils";
 
 interface IGroup {
     id_classe: string;
@@ -17,11 +18,11 @@ export class Group implements IGroup {
     id_structure: string;
 
     addGroupIds(groupIds: string[]): void {
-        if(groupIds) this.id_groups = [...groupIds, ...this.id_groups];
+        if (groupIds) this.id_groups = [...groupIds, ...this.id_groups];
     }
 
     addGroupNames(groupNames: string[]): void {
-        if(groupNames) this.name_groups = [...groupNames, ...this.id_groups];
+        if (groupNames) this.name_groups = [...groupNames, ...this.id_groups];
     };
 }
 
@@ -41,6 +42,10 @@ export class Groups {
         this.all = data;
     }
 
+    set = (groups: Group[]): void => {
+        this.all = groups;
+    }
+
     /**
      * Returns first structure occurrence in the class
      * @returns {Group} first group contained in 'all' array
@@ -51,10 +56,19 @@ export class Groups {
 
     get = (groupClassId: string): Group => this.all.find((s: Group) => s.id_classe == groupClassId);
 
+    getIds = (): string[] =>
+        ArrayUtils.flat(this.all.map((group: Group) => {
+            let groupIds: string[] = group.id_groups || [];
+            if (group.id_classe) groupIds.push(group.id_classe);
+            return groupIds;
+        }))
+
     add(group: Group): void {
         this.all.push(group);
     }
 
+    addAll = (groups: Group[]): void => groups.forEach((group: Group) => this.add(group));
+
     getGroupsFromStudent = (student: Student): Group =>
-        this.all.find((group: Group)  => !!group.id_groups.find((groupId: string) => groupId === student.groupId));
+        this.all.find((group: Group) => !!group.id_groups.find((groupId: string) => groupId === student.groupId));
 }

--- a/src/main/resources/public/ts/model/homework.ts
+++ b/src/main/resources/public/ts/model/homework.ts
@@ -253,13 +253,13 @@ export class Homeworks {
         return dataModel;
     }
 
-    async syncOwnHomeworks(structure: any, startMoment: any, endMoment: any, subjectId?: string, teacherId?: string, audienceId?: string): Promise<void> {
+    async syncOwnHomeworks(structure: any, startMoment: any, endMoment: any, subjectId?: string, teacherId?: string, audienceIds?: string[]): Promise<void> {
         let startDate: string = DateUtils.getFormattedDate(startMoment);
         let endDate: string = DateUtils.getFormattedDate(endMoment);
 
-        let filter: string = subjectId || teacherId || audienceId ? '?' : '';
+        let filter: string = subjectId || teacherId || audienceIds ? '?' : '';
         if (teacherId) filter += `teacherId=${teacherId}&`;
-        if (audienceId) filter += `audienceId=${audienceId}&`;
+        if (audienceIds) filter += audienceIds.map((id: string) => `audienceId=${id}`).join('&') + '&';
         if (subjectId) filter += `subjectId=${subjectId}&`;
 
         let url: string = `/diary/homeworks/own/${startDate}/${endDate}/${this.structure.id}${filter.slice(0, -1)}`;
@@ -267,13 +267,13 @@ export class Homeworks {
         await this.syncHomeworks(url);
     }
 
-    async syncExternalHomeworks(startMoment: any, endMoment: any, teacherId?: string, audienceId?: string, subjectId?: string): Promise<void> {
+    async syncExternalHomeworks(startMoment: any, endMoment: any, teacherId?: string, audienceIds?: string[], subjectId?: string): Promise<void> {
         let startDate: string = DateUtils.getFormattedDate(startMoment);
         let endDate: string = DateUtils.getFormattedDate(endMoment);
 
-        let filter: string = teacherId || audienceId ? '?' : '';
+        let filter: string = teacherId || audienceIds ? '?' : '';
         if (teacherId) filter += `teacherId=${teacherId}&`;
-        if (audienceId) filter += `audienceId=${audienceId}&`;
+        if (audienceIds) filter += audienceIds.map((id: string) => `audienceId=${id}`).join('&') + '&';
         if (subjectId) filter += `subjectId=${subjectId}&`;
 
         let url: string = `/diary/homeworks/external/${startDate}/${endDate}${filter.slice(0, -1)}`;

--- a/src/main/resources/public/ts/model/session.ts
+++ b/src/main/resources/public/ts/model/session.ts
@@ -396,13 +396,13 @@ export class Sessions {
         await this.syncSessions(url);
     }
 
-    async syncExternalSessions(startMoment: any, endMoment: any, teacherId?: string, audienceId?: string, subjectId?: string): Promise<void> {
+    async syncExternalSessions(startMoment: any, endMoment: any, teacherId?: string, audienceIds?: string[], subjectId?: string): Promise<void> {
         let startDate = DateUtils.getFormattedDate(startMoment);
         let endDate = DateUtils.getFormattedDate(endMoment);
 
-        let filter = teacherId || audienceId ? '?' : '';
+        let filter = teacherId || audienceIds ? '?' : '';
         if (teacherId) filter += `teacherId=${teacherId}&`;
-        if (audienceId) filter += `audienceId=${audienceId}&`;
+        if (audienceIds) filter += audienceIds.map((id: string) => `audienceId=${id}`).join('&') + '&';
         if (subjectId) filter += `&subjectId=${subjectId}`;
         let url = `/diary/sessions/external/${startDate}/${endDate}${filter.slice(0, -1)}`;
 

--- a/src/main/resources/public/ts/services/group.service.ts
+++ b/src/main/resources/public/ts/services/group.service.ts
@@ -5,6 +5,8 @@ import {Mix} from "entcore-toolkit";
 
 export interface GroupService {
     initGroupsFromStudentIds(studentIds: string[]): Promise<Group[]>;
+
+    initGroupsFromClassNames(classIds: string[]): Promise<Group[]>;
 }
 
 export const groupService: GroupService = {
@@ -12,6 +14,17 @@ export const groupService: GroupService = {
         try {
             let studentParams: string = studentIds.map((id: string) => `student=${id}`).join('&');
             let {data} = await http.get(`/viescolaire/group/from/class?${studentParams}`);
+            return Mix.castArrayAs(Group, data);
+        } catch (err) {
+            throw err;
+        }
+    },
+
+
+    initGroupsFromClassNames: async (classIds: string[]): Promise<Group[]> => {
+        try {
+            let groupParams: string = classIds.map((name: string) => `classes=${name}`).join('&');
+            let {data} = await http.get(`/viescolaire/group/from/class?${groupParams}`);
             return Mix.castArrayAs(Group, data);
         } catch (err) {
             throw err;

--- a/src/main/resources/public/ts/utils/autocomplete/audiencesSearch.ts
+++ b/src/main/resources/public/ts/utils/autocomplete/audiencesSearch.ts
@@ -1,0 +1,78 @@
+import {AutoCompleteUtils} from "./auto-complete";
+import {groupService, SearchItem, SearchService} from "../../services";
+import {Audience} from "../../model";
+import {Group} from '../../model/group';
+
+
+/**
+ * ⚠ This class is used for the directive async-autocomplete
+ * use it for group only (groups/classes)
+ */
+
+export class AudiencesSearch extends AutoCompleteUtils {
+
+    private searchItems: SearchItem[];
+    private selectedAudiences: Audience[];
+
+    public searchQuery: string;
+
+    constructor(structureId: string, searchService: SearchService) {
+        super(structureId, searchService);
+    }
+
+    public getAudiences(): SearchItem[] {
+        return this.searchItems;
+    }
+
+    public getSelectedAudiences(): SearchItem[] {
+        return this.selectedAudiences ? this.selectedAudiences : [];
+    }
+
+    public setSelectedAudiences(selectedAudiences: Audience[]): void {
+        this.selectedAudiences = selectedAudiences;
+    }
+
+    public async removeSelectedAudience(audience: Audience): Promise<void> {
+        let groups: Array<Group> = await groupService.initGroupsFromClassNames([audience.id]);
+
+        if (groups.length > 0) {
+            this.resetSelectedAudiences();
+        } else {
+            this.selectedAudiences.splice(this.selectedAudiences.indexOf(audience), 1);
+        }
+    }
+
+    public resetSearch(): void {
+        this.searchQuery = '';
+        this.resetSearchItems();
+    }
+
+    public resetSearchItems(): void {
+        this.searchItems = [];
+    }
+
+    public resetSelectedAudiences(): void {
+        this.selectedAudiences = [];
+    }
+
+    public selectAudiences(valueInput: string, audienceItem: Audience): void {
+        if (!this.selectedAudiences) this.selectedAudiences = [];
+        if (!this.selectedAudiences.find((audience: Audience) => audience.id === audienceItem.id))
+            this.selectedAudiences.push(audienceItem);
+    };
+
+    public selectGroup(valueInput: string, audienceItem: Audience): void {
+        this.selectedAudiences = [];
+        this.selectedAudiences.push(audienceItem);
+    }
+
+    public async searchAudiences(valueInput: string): Promise<void> {
+        try {
+            this.searchItems = await this.searchService.searchGroup(this.structureId, valueInput);
+            this.searchItems.forEach((group: SearchItem) => group.toString = () => group.name);
+        } catch (err) {
+            this.searchItems = [];
+            throw err;
+        }
+    };
+}


### PR DESCRIPTION
[Jira - MCDT-566](https://entsupport.gdapublic.fr/secure/RapidBoard.jspa?rapidView=36&projectKey=MCDT&view=detail&selectedIssue=MCDT-566)

Sur les vues contenant des recherches de classes (calendaire, liste, liste de cdt...), on permet désormais le filtrage des données avec des classes multiples. On permet aussi de présélectionner les groupes liés à la classe qu'on sélectionne (afin d'avoir les données de tous les groupes qui sont liés à la classe en question).

Le résultat de la recherche est désormais affiché sur la sidebar (lorsqu'elle est présente).
![image](https://user-images.githubusercontent.com/55873580/141500807-3268b895-13f3-4193-96f6-18ef665e4c3f.png)
