### PR TITLE
fix(homework): #MCDT-577 fix invalid next session

### DIFF
--- a/src/main/resources/public/ts/controllers/homework/manageHomework.ts
+++ b/src/main/resources/public/ts/controllers/homework/manageHomework.ts
@@ -155,8 +155,6 @@ export let manageHomeworkCtrl = ng.controller('manageHomeworkCtrl',
                                 return false;
                             });
                     }
-
-                    linkSession();
                     if ($scope.session || courses.length !== 0 || $scope.sessions.all.length !== 0) {
                         $scope.display.sessionSelect = true;
                     } else {
@@ -171,56 +169,9 @@ export let manageHomeworkCtrl = ng.controller('manageHomeworkCtrl',
                 });
             };
 
-
-            const checkIsAfter = (s: Session): boolean => {
-                if ($scope.session) {
-                    let isAfter: boolean = false;
-
-                    if (moment(s.date).format(FORMAT['YEAR/MONTH/DAY']) === moment($scope.session.date).format(FORMAT['YEAR/MONTH/DAY'])
-                        && moment(s.startTime).hours() * 60 + moment(s.startTime).minutes()
-                        < moment($scope.session.startTime).hours() * 60 + moment($scope.session.startTime).minutes()) {
-                        isAfter = true;
-                    }
-
-                    return isAfter;
-                } else {
-                    return false;
-                }
-            }
-
             $scope.isSessionFuture = (): boolean => {
                 return ($scope.homework.session && $scope.homework.session.date) ?
                     moment($scope.homework.session.date).isAfter(moment()) : true;
-            }
-
-            // Clear previous session and linkToHomework current session
-            const linkSession = (): Session[] => {
-                let isIndependant: boolean = true;
-                for (let i = 0; i < $scope.sessionsToAttachTo.length; i++) {
-                    let s: Session = $scope.sessionsToAttachTo[i];
-                    if ($scope.session && (s.isSameSession($scope.session))
-                        || ($scope.session && s.id && $scope.session.id && $scope.session.id === s.id)) {
-                        s.firstText = lang.translate("session.manage.linkhomework")
-                        isIndependant = false;
-                    }
-
-                    if (checkIsAfter(s)) {
-                        $scope.sessionsToAttachTo.splice($scope.sessionsToAttachTo.indexOf(s), 1);
-                        i--;
-                    }
-
-                    if ($scope.homework.session && moment(s.date).isSame(moment($scope.homework.session.date))
-                        && $scope.homework.session && moment(s.startTime).isSame(moment($scope.homework.session.startTime)))
-                        $scope.homework.session = s
-
-                }
-                if (isIndependant && $scope.session && !$scope.session.id) {
-                    $scope.session.firstText = lang.translate("session.manage.linkhomework")
-                    $scope.sessionsToAttachTo.unshift($scope.session)
-
-                }
-
-                return $scope.sessionsToAttachTo;
             }
 
             $scope.attachToSession = (): void => {

--- a/src/main/resources/public/ts/model/session.ts
+++ b/src/main/resources/public/ts/model/session.ts
@@ -269,10 +269,13 @@ export class Session {
      * Returns the session info text.
      */
     getSessionString = (): string => {
-        return this.audience.name + ' - ' + this.getSubjectTitle() + ' - '
-            + moment.weekdays(true)[moment(this.startDisplayDate, FORMAT.displayDate).weekday()] + ' '
-            + this.startDisplayDate + ' ' + this.startDisplayTime
-            + ' - ' + this.endDisplayTime;
+        if (this.audience && this.audience.name && this.startDisplayDate && this.endDisplayDate) {
+            return this.audience.name + ' - ' + this.getSubjectTitle() + ' - '
+                + moment.weekdays(true)[moment(this.startDisplayDate, FORMAT.displayDate).weekday()] + ' '
+                + this.startDisplayDate + ' ' + this.startDisplayTime
+                + ' - ' + this.endDisplayTime;
+        }
+        return "";
     }
 
     getSessionInfo(session: Session): void {


### PR DESCRIPTION
## Describe your changes
When you are on a session and you add an homework, you add an option to be able to put the homework on this session. But when creating an homework directly from the button, this option is added when you are not attached to a session. Which causes undefine. We can simply not add this seesion in the table of sessions

## Checklist tests
Go to the calendar view, create a homework from the button. Select session, then select a session.
To avoid regression, check that you always have "Link to session" when creating a homework from a session

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MCDT-577

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

