### PR TITLE
fix(list): #MCDT-584 fix not display seance with only screen

### DIFF
--- a/src/main/resources/public/ts/directives/async-autocomplete.ts
+++ b/src/main/resources/public/ts/directives/async-autocomplete.ts
@@ -1,4 +1,5 @@
 import {$, idiom as lang, ng} from 'entcore';
+import {safeApply} from "../utils/safeApply";
 
 export const asyncAutocomplete = ng.directive('asyncAutocomplete', ['$timeout', ($timeout) => ({
     restrict: 'E',
@@ -50,7 +51,7 @@ export const asyncAutocomplete = ng.directive('asyncAutocomplete', ['$timeout', 
 
         const setLoadingStatus = (status: boolean = true) => {
             $scope.loading = status;
-            $scope.$apply();
+            safeApply($scope);
         };
 
         const endUserTyping = () => {
@@ -63,7 +64,7 @@ export const asyncAutocomplete = ng.directive('asyncAutocomplete', ['$timeout', 
             $scope.match = newVal;
             cancelAnimationFrame(token);
             setLoadingStatus(false);
-            $scope.$apply();
+            safeApply($scope);
         });
 
         $scope.select = (option) => {
@@ -74,7 +75,7 @@ export const asyncAutocomplete = ng.directive('asyncAutocomplete', ['$timeout', 
         const closeDropDown = function () {
             setLoadingStatus(false);
             $scope.match = undefined;
-            $scope.$apply();
+            safeApply($scope);
         };
 
         linkedInput.on('keyup', () => {

--- a/src/main/resources/public/ts/model/__mocks__/entcore.ts
+++ b/src/main/resources/public/ts/model/__mocks__/entcore.ts
@@ -1,0 +1,61 @@
+import {Moment} from "moment";
+
+declare let require: any;
+
+export const moment: Moment = require("moment");
+
+interface IController {
+    name: string;
+    contents: any;
+}
+interface IDirective {
+    name: string;
+    contents: any;
+}
+interface IService {
+    name: string;
+    contents: any;
+}
+
+const controllers: Array<IController> = [];
+const directives: Array<IDirective> = [];
+const services: Array<IService> = [];
+
+export const ng = {
+    service: jest.fn((name: string, contents: any): void => {
+        this.ng.services.push({name, contents});
+    }),
+    directive: jest.fn((name: string, contents: any): void => {
+        this.ng.directives.push({name, contents});
+    }),
+    controller: jest.fn((name: string, contents: any): void => {
+        this.ng.controllers.push({name, contents});
+    }),
+    // init services, controller and directives
+    initMockedModules: jest.fn((app: any): void => {
+        this.ng.services.forEach((s) => app.service(s.name, s.contents));
+        this.ng.directives.forEach((d) => app.directive(d.name, d.contents));
+        this.ng.controllers.forEach((c) => app.controller(c.name, c.contents));
+    }),
+    controllers: controllers,
+    directives: directives,
+    services: services,
+};
+
+export const model = {
+    calendar: {
+        dayForWeek: '2017-01-12T14:00:00.000+01:00'
+    },
+    me: {
+        userId: '7b6459f5-2765-45b5-8086-d5b3f422e69e',
+        type: 'PERSEDUCNAT',
+        hasWorkflow: jest.fn(() => true),
+        hasRight: jest.fn(() => true),
+        structures: [],
+        structureNames: []
+    },
+};
+
+export const idiom = {
+    translate: jest.fn((key : string) => key)
+};

--- a/src/main/resources/public/ts/utils/__tests__/dateUtils.utils.test.ts
+++ b/src/main/resources/public/ts/utils/__tests__/dateUtils.utils.test.ts
@@ -1,0 +1,28 @@
+import {ng} from '../../model/__mocks__/entcore';
+
+import {DateUtils} from "../dateUtils";
+import DoneCallback = jest.DoneCallback;
+
+describe('dateUtils',  () => {
+    it('test convertHtmlToPlainText method', (done: DoneCallback) => {
+        let html: string = "";
+        let expected: string = "";
+        expect(DateUtils.convertHtmlToPlainText(html)).toEqual(expected);
+        html = "Bonjour";
+        expected = "Bonjour";
+        expect(DateUtils.convertHtmlToPlainText(html)).toEqual(expected);
+        html = "<html></html>";
+        expected = "";
+        expect(DateUtils.convertHtmlToPlainText(html)).toEqual(expected);
+        html = "<html>Bonjour<div>A</div><p>Tous</p></html>";
+        expected = "BonjourA Tous";
+        expect(DateUtils.convertHtmlToPlainText(html)).toEqual(expected);
+        html = "<html>Bonjour <img source\"urlsource\"/><p>World</p></html>";
+        expected = "Bonjour <img source\"urlsource\"/>World";
+        expect(DateUtils.convertHtmlToPlainText(html)).toEqual(expected);
+        html = "<html>Bonjour <img source\"urlsource\">World</img></html>";
+        expected = "Bonjour <img source\"urlsource\">World</img>";
+        expect(DateUtils.convertHtmlToPlainText(html)).toEqual(expected);
+        done();
+    });
+});

--- a/src/main/resources/public/ts/utils/dateUtils.ts
+++ b/src/main/resources/public/ts/utils/dateUtils.ts
@@ -81,21 +81,9 @@ export class DateUtils {
         return xhtml;
     }
 
-    static safeApply(that) {
-        return new Promise((resolve, reject) => {
-            let phase = (that.$root !== null) ? that.$root.$$phase : undefined;
-            if (phase === '$apply' || phase === '$digest') {
-                if (resolve && (typeof (resolve) === 'function')) resolve();
-            } else {
-                if (resolve && (typeof (resolve) === 'function')) that.$apply(resolve);
-                else that.$apply();
-            }
-        });
-    }
-
     static convertHtmlToPlainText(html) {
         let htmlWithSpaces = html.replace(/<\/div>/g, ' </div>');
-        return htmlWithSpaces ? String(htmlWithSpaces).replace(/<[^>]+>/gm, '') : '';
+        return htmlWithSpaces ? String(htmlWithSpaces).replace(/<(?!(\/)*img)[^>]+>/gm, '') : '';
     }
 
     static isAChildOrAParent(type) {

--- a/src/main/resources/public/ts/utils/safeApply.ts
+++ b/src/main/resources/public/ts/utils/safeApply.ts
@@ -1,0 +1,9 @@
+/**
+ * Safe apply to use for sniplets and directives.
+ */
+export function safeApply($scope: any) {
+    let phase = $scope.$root.$$phase;
+    if (phase !== '$apply' && phase !== '$digest') {
+        $scope.$apply();
+    }
+}


### PR DESCRIPTION
## Describe your changes
When a session has only one image in description it does not appear in list.
Basically we filter all the html tags to retrieve only the text of the description. Then we check the length of the text. The img tag being filter the length of the text was empty and was not displayed in the list.
By modifying the filter regex to select the img tag, the length is no longer empty and the session is displayed.

## Checklist tests
Create a session with only one image, check if it is displayed in the list.

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MCDT-584

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

