### PR TITLE
fix(seance): #MCDT-590 fix impossible to save a session after delete homework

### DIFF
--- a/src/main/resources/public/ts/controllers/calendar/calendar-view.ts
+++ b/src/main/resources/public/ts/controllers/calendar/calendar-view.ts
@@ -26,7 +26,6 @@ import {EXCEPTIONAL} from '../../core/const/exceptional-subject';
 import {MobileUtils} from "../../utils/mobile";
 import {IAngularEvent} from "angular";
 import {UserUtils} from "../../utils/user.utils";
-import {PEDAGOGIC_SLOT_PROFILE} from "../../core/enum/pedagogic-slot-profile";
 import {DAY_OF_WEEK} from "../../core/enum/dayOfWeek.enum";
 import {Group, Groups} from "../../model/group";
 
@@ -59,8 +58,6 @@ export let calendarController = ng.controller('CalendarController',
             $scope.TYPE_HOMEWORK = PEDAGOGIC_TYPES.TYPE_HOMEWORK;
             $scope.TYPE_SESSION = PEDAGOGIC_TYPES.TYPE_SESSION;
             $scope.TYPE_COURSE = PEDAGOGIC_TYPES.TYPE_COURSE;
-
-            const pedagogicSlotProfile: typeof PEDAGOGIC_SLOT_PROFILE = PEDAGOGIC_SLOT_PROFILE;
 
             $scope.timeSlot = {
                 slots: null

--- a/src/main/resources/public/ts/controllers/session/manageSession.ts
+++ b/src/main/resources/public/ts/controllers/session/manageSession.ts
@@ -263,6 +263,9 @@ export let manageSessionCtrl = ng.controller('manageSessionCtrl',
             $scope.deleteHomework = async (homework: Homework, index: number, array_concerned?: string): Promise<void> => {
                 if (($scope.session.id === homework.session_id) || (array_concerned && array_concerned == $scope.CONST_HOMEWORKS)) {
                     $scope.localRemoveHomework(index);
+                    //If this condition is true, then when deleting the homework we delete the session in back
+                    if ($scope.homeworks.length == 0 && !$scope.session.isSession())
+                        $scope.session.isDeleted = true;
                 } else {
                     $scope.localRemoveFromHomework(index);
                 }

--- a/src/main/resources/public/ts/core/enum/pedagogic-slot-profile.ts
+++ b/src/main/resources/public/ts/core/enum/pedagogic-slot-profile.ts
@@ -1,4 +1,0 @@
-export enum PEDAGOGIC_SLOT_PROFILE {
-    SESSION = '#00ab6f',
-    HOMEWORK = '#ff9700'
-}

--- a/src/main/resources/public/ts/model/session.ts
+++ b/src/main/resources/public/ts/model/session.ts
@@ -51,6 +51,7 @@ export class Session {
     firstText?: string = '';
     pedagogicType: number = PEDAGOGIC_TYPES.TYPE_SESSION;
     string: string = '';
+    isDeleted: boolean = false;
 
     constructor(structure: Structure, course?: Course, progression?: ProgressionSession) {
         this.structure = structure;
@@ -193,16 +194,14 @@ export class Session {
     }
 
     async save(placeholder?) {
-        if (this.id) {
+        if (this.id && !this.isDeleted) {
             let response = await http.put('/diary/session/' + this.id, this.toSendFormat(placeholder));
             return ToastUtils.setToastMessage(response, 'session.updated', 'session.updated.error');
-
         } else {
             let response = await http.post('/diary/session', this.toSendFormat(placeholder));
             this.id = response.data.id;
 
             return ToastUtils.setToastMessage(response, 'session.created', 'session.created.error');
-
         }
     }
 
@@ -345,6 +344,14 @@ export class Session {
 
         return (moment(otherSessionTime).isSame(moment(currentSessionTime)));
     }
+
+    isSession(): boolean {
+        if (this.color) {
+            // #00ab6f represents session's color and #7E7E7E represents session that does not match timeslot
+            return this.color === colors[0] || this.color === colors[1];
+        }
+        return false;
+    };
 
 }
 


### PR DESCRIPTION
## Describe your changes
When you put an homework for the next session, you create a session with only an homework. Once you delete the homework, you also delete the session because it is empty. If we do it from the session, we can no longer modify the session because it no longer exists. Recreate a session instead of updating it fixes the problem.

## Checklist tests
Give a homework to do for a next session. Go to the next session, delete the homework. Add a description, then save.

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MCDT-590

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

