### PR TITLE
fix(homework): #MA-588 fix display when a homework has no session

### DIFF
--- a/src/main/java/fr/openent/diary/services/impl/HomeworkServiceImpl.java
+++ b/src/main/java/fr/openent/diary/services/impl/HomeworkServiceImpl.java
@@ -440,7 +440,7 @@ public class HomeworkServiceImpl extends SqlCrudService implements HomeworkServi
         JsonArray values = new JsonArray();
         String query = "UPDATE " + Diary.DIARY_SCHEMA + ".homework " +
                 "SET subject_id = ?, exceptional_label = ?, structure_id = ?, audience_id = ?, estimatedTime = ?," +
-                " color = ?, description = ?, type_id = ?,  modified = NOW() " ;
+                " color = ?, description = ?, type_id = ?, session_id = ?,  modified = NOW() " ;
 
         values.add(homework.getString("subject_id"));
         if (homework.getString("exceptional_label") != null) {
@@ -454,15 +454,12 @@ public class HomeworkServiceImpl extends SqlCrudService implements HomeworkServi
         values.add(homework.getString("color"));
         values.add(homework.getString("description"));
         values.add(homework.getInteger("type_id"));
+        //If session_id is null in the json, we explicitly authorize to update session_id to null
+        values.add(homework.getInteger("session_id"));
 
         if(homework.getBoolean("is_published") != null) {
             query += ", is_published = ?";
             values.add(homework.getBoolean("is_published"));
-        }
-
-        if (homework.getInteger("session_id") != null) {
-            query += ", session_id = ?";
-            values.add(homework.getInteger("session_id"));
         }
 
         if (homework.getString("due_date") != null) {

--- a/src/main/resources/public/template/homework/homework-form.html
+++ b/src/main/resources/public/template/homework/homework-form.html
@@ -96,7 +96,7 @@
                         <date-picker class="date-picker-sm margin-bottom-7"  ng-if="homework.attachedToDate"
                                      ng-model="homework.dueDate"  ng-change="syncWorkloadDay()">
                         </date-picker>
-                        <select ng-if="homework.attachedToSession && (isSessionFuture() || !homework.id)" ng-model="homework.session" ng-click="syncWorkloadDay()"
+                        <select ng-if="homework.attachedToSession && ((homework.session && isSessionFuture()) || !homework.id)" ng-model="homework.session" ng-click="syncWorkloadDay()"
                                 ng-options="session as (session.getSessionString()) for session in sessionsToAttachTo">
                         </select>
                         <span ng-if="homework.attachedToSession && !isSessionFuture() && homework.id">

--- a/src/main/resources/public/ts/model/homework.ts
+++ b/src/main/resources/public/ts/model/homework.ts
@@ -201,7 +201,9 @@ export class Homework {
 
     init(): void {
         this.type = Mix.castAs(HomeworkType, this.type);
-        this.session = Mix.castAs(Session, this.type);
+        //if the session is not null, the homework must be detached from its previous session.
+        //if the session is null, the homework is not attached to any session, so we do nothing.
+        this.session = this.session ? Mix.castAs(Session, this.type) : this.session;
         this.dueDate = moment(this.dueDate).toDate();
         if (this.session_id && this.session_date) {
             this.startMoment = moment(this.session_date);

--- a/src/test/java/fr/openent/diary/services/impl/HomeworkServiceImplTest.java
+++ b/src/test/java/fr/openent/diary/services/impl/HomeworkServiceImplTest.java
@@ -261,11 +261,11 @@ public class HomeworkServiceImplTest {
     public void testUpdateHomework(TestContext ctx) {
         Async async = ctx.async();
 
-        String expectedQuery = "UPDATE diary.homework SET subject_id = ?, exceptional_label = ?, structure_id = ?, " +
-                "audience_id = ?, estimatedTime = ?, color = ?, description = ?, type_id = ?,  modified = NOW() , is_published = ?, " +
-                "session_id = ?, due_date = ?,publish_date = NOW ()   WHERE id = ?;";
+        String expectedQuery = "UPDATE diary.homework SET subject_id = ?, exceptional_label = ?, structure_id = ?, audience_id" +
+                " = ?, estimatedTime = ?, color = ?, description = ?, type_id = ?, session_id = ?,  modified = NOW() ," +
+                " is_published = ?, due_date = ?,publish_date = NOW ()   WHERE id = ?;";
         JsonArray expectedParams = new JsonArray(Arrays.asList(
-                "subject_id", "exceptional_label", "structure_id", "audience_id", 1, "color", "description", 3, true, 4, "due_date", 1
+                "subject_id","exceptional_label","structure_id","audience_id",1,"color","description",3,4,true,"due_date",1
         ));
 
         vertx.eventBus().consumer("fr.openent.diary", message -> {
@@ -281,6 +281,34 @@ public class HomeworkServiceImplTest {
         JsonObject homework = new JsonObject("{\"is_published\": true, \"subject_id\": \"subject_id\", \"exceptional_label\":" +
                 " \"exceptional_label\", \"structure_id\": \"structure_id\", \"audience_id\": \"audience_id\", \"estimatedTime\": 1," +
                 " \"color\": \"color\", \"description\": \"description\", \"from_session_id\": 5, \"session_id\": 4, \"due_date\":" +
+                " \"due_date\", \"type_id\": 3}");
+        this.homeworkServiceImpl.updateHomework(1, true, homework, null);
+    }
+
+    @Test
+    public void testUpdateHomeworkWithNullSessionId(TestContext ctx) {
+        Async async = ctx.async();
+
+        String expectedQuery = "UPDATE diary.homework SET subject_id = ?, exceptional_label = ?, structure_id = ?, audience_id" +
+                " = ?, estimatedTime = ?, color = ?, description = ?, type_id = ?, session_id = ?,  modified = NOW() ," +
+                " is_published = ?, due_date = ?,publish_date = NOW ()   WHERE id = ?;";
+        JsonArray expectedParams = new JsonArray(Arrays.asList(
+                "subject_id","exceptional_label","structure_id","audience_id",1,"color","description",3,null,true,"due_date",1
+        ));
+
+        vertx.eventBus().consumer("fr.openent.diary", message -> {
+            JsonObject body = (JsonObject) message.body();
+            ctx.assertEquals("prepared", body.getString("action"));
+            ctx.assertEquals(expectedQuery, body.getString("statement"));
+            ctx.assertEquals(expectedParams.toString(), body.getJsonArray("values").toString());
+            async.complete();
+        });
+
+        UserInfos user = new UserInfos();
+        user.setUserId("userId");
+        JsonObject homework = new JsonObject("{\"is_published\": true, \"subject_id\": \"subject_id\", \"exceptional_label\":" +
+                " \"exceptional_label\", \"structure_id\": \"structure_id\", \"audience_id\": \"audience_id\", \"estimatedTime\": 1," +
+                " \"color\": \"color\", \"description\": \"description\", \"from_session_id\": 5, \"session_id\": null, \"due_date\":" +
                 " \"due_date\", \"type_id\": 3}");
         this.homeworkServiceImpl.updateHomework(1, true, homework, null);
     }


### PR DESCRIPTION
## Describe your changes
When modifying an homework, the selection to modify the date or the session no longer worked.

## Checklist tests
Be able to modify the date of the assignment in session or on a specific date for an upcoming homework.
Not being able to change the date of an homework that was for a past session.
Be able to change the date of an homework to a past date.

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MCDT-588

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

