### PR TITLE
fix(homework): #MCDT-591 fix api homework update session_id

### DIFF
--- a/src/main/java/fr/openent/diary/services/impl/HomeworkServiceImpl.java
+++ b/src/main/java/fr/openent/diary/services/impl/HomeworkServiceImpl.java
@@ -440,7 +440,7 @@ public class HomeworkServiceImpl extends SqlCrudService implements HomeworkServi
         JsonArray values = new JsonArray();
         String query = "UPDATE " + Diary.DIARY_SCHEMA + ".homework " +
                 "SET subject_id = ?, exceptional_label = ?, structure_id = ?, audience_id = ?, estimatedTime = ?," +
-                " color = ?, description = ?, type_id = ?, session_id = ?,  modified = NOW() " ;
+                " color = ?, description = ?, type_id = ?, modified = NOW() " ;
 
         values.add(homework.getString("subject_id"));
         if (homework.getString("exceptional_label") != null) {
@@ -454,8 +454,11 @@ public class HomeworkServiceImpl extends SqlCrudService implements HomeworkServi
         values.add(homework.getString("color"));
         values.add(homework.getString("description"));
         values.add(homework.getInteger("type_id"));
-        //If session_id is null in the json, we explicitly authorize to update session_id to null
-        values.add(homework.getInteger("session_id"));
+
+        if(homework.getInteger("session_id") != null || Boolean.TRUE.equals(homework.getBoolean("detachFromSession"))) {
+            query += ", session_id = ?";
+            values.add(homework.getInteger("session_id"));
+        }
 
         if(homework.getBoolean("is_published") != null) {
             query += ", is_published = ?";

--- a/src/main/resources/public/ts/model/homework.ts
+++ b/src/main/resources/public/ts/model/homework.ts
@@ -77,7 +77,8 @@ export class Homework {
             description: DateUtils.htmlToXhtml(this.description),
             color: this.color,
             is_published: this.isPublished,
-            workload: this.workload
+            workload: this.workload,
+            detachFromSession: (!this.session || !this.session.id)
         };
     }
 

--- a/src/test/java/fr/openent/diary/services/impl/HomeworkServiceImplTest.java
+++ b/src/test/java/fr/openent/diary/services/impl/HomeworkServiceImplTest.java
@@ -261,12 +261,10 @@ public class HomeworkServiceImplTest {
     public void testUpdateHomework(TestContext ctx) {
         Async async = ctx.async();
 
-        String expectedQuery = "UPDATE diary.homework SET subject_id = ?, exceptional_label = ?, structure_id = ?, audience_id" +
-                " = ?, estimatedTime = ?, color = ?, description = ?, type_id = ?, session_id = ?,  modified = NOW() ," +
-                " is_published = ?, due_date = ?,publish_date = NOW ()   WHERE id = ?;";
-        JsonArray expectedParams = new JsonArray(Arrays.asList(
-                "subject_id","exceptional_label","structure_id","audience_id",1,"color","description",3,4,true,"due_date",1
-        ));
+        String expectedQuery = "UPDATE diary.homework SET subject_id = ?, exceptional_label = ?, structure_id = ?, audience_id =" +
+                " ?, estimatedTime = ?, color = ?, description = ?, type_id = ?, modified = NOW() , session_id = ?, is_published =" +
+                " ?, due_date = ?,publish_date = NOW ()   WHERE id = ?;";
+        JsonArray expectedParams = new JsonArray(Arrays.asList("subject_id","exceptional_label","structure_id","audience_id",1,"color","description",3,4,true,"due_date",1));
 
         vertx.eventBus().consumer("fr.openent.diary", message -> {
             JsonObject body = (JsonObject) message.body();
@@ -281,7 +279,7 @@ public class HomeworkServiceImplTest {
         JsonObject homework = new JsonObject("{\"is_published\": true, \"subject_id\": \"subject_id\", \"exceptional_label\":" +
                 " \"exceptional_label\", \"structure_id\": \"structure_id\", \"audience_id\": \"audience_id\", \"estimatedTime\": 1," +
                 " \"color\": \"color\", \"description\": \"description\", \"from_session_id\": 5, \"session_id\": 4, \"due_date\":" +
-                " \"due_date\", \"type_id\": 3}");
+                " \"due_date\", \"type_id\": 3, \"detachFromSession\":true}");
         this.homeworkServiceImpl.updateHomework(1, true, homework, null);
     }
 
@@ -290,11 +288,9 @@ public class HomeworkServiceImplTest {
         Async async = ctx.async();
 
         String expectedQuery = "UPDATE diary.homework SET subject_id = ?, exceptional_label = ?, structure_id = ?, audience_id" +
-                " = ?, estimatedTime = ?, color = ?, description = ?, type_id = ?, session_id = ?,  modified = NOW() ," +
-                " is_published = ?, due_date = ?,publish_date = NOW ()   WHERE id = ?;";
-        JsonArray expectedParams = new JsonArray(Arrays.asList(
-                "subject_id","exceptional_label","structure_id","audience_id",1,"color","description",3,null,true,"due_date",1
-        ));
+                " = ?, estimatedTime = ?, color = ?, description = ?, type_id = ?, modified = NOW() , is_published = ?, due_date" +
+                " = ?,publish_date = NOW ()   WHERE id = ?;";
+        JsonArray expectedParams = new JsonArray(Arrays.asList("subject_id","exceptional_label","structure_id","audience_id",1,"color","description",3,true,"due_date",1));
 
         vertx.eventBus().consumer("fr.openent.diary", message -> {
             JsonObject body = (JsonObject) message.body();
@@ -310,6 +306,32 @@ public class HomeworkServiceImplTest {
                 " \"exceptional_label\", \"structure_id\": \"structure_id\", \"audience_id\": \"audience_id\", \"estimatedTime\": 1," +
                 " \"color\": \"color\", \"description\": \"description\", \"from_session_id\": 5, \"session_id\": null, \"due_date\":" +
                 " \"due_date\", \"type_id\": 3}");
+        this.homeworkServiceImpl.updateHomework(1, true, homework, null);
+    }
+
+    @Test
+    public void testUpdateHomeworkDetachSession(TestContext ctx) {
+        Async async = ctx.async();
+
+        String expectedQuery = "UPDATE diary.homework SET subject_id = ?, exceptional_label = ?, structure_id = ?, audience_id" +
+                " = ?, estimatedTime = ?, color = ?, description = ?, type_id = ?, modified = NOW() , session_id = ?, is_published" +
+                " = ?, due_date = ?,publish_date = NOW ()   WHERE id = ?;";
+        JsonArray expectedParams = new JsonArray(Arrays.asList("subject_id","exceptional_label","structure_id","audience_id",1,"color","description",3,null,true,"due_date",1));
+
+        vertx.eventBus().consumer("fr.openent.diary", message -> {
+            JsonObject body = (JsonObject) message.body();
+            ctx.assertEquals("prepared", body.getString("action"));
+            ctx.assertEquals(expectedQuery, body.getString("statement"));
+            ctx.assertEquals(expectedParams.toString(), body.getJsonArray("values").toString());
+            async.complete();
+        });
+
+        UserInfos user = new UserInfos();
+        user.setUserId("userId");
+        JsonObject homework = new JsonObject("{\"is_published\": true, \"subject_id\": \"subject_id\", \"exceptional_label\":" +
+                " \"exceptional_label\", \"structure_id\": \"structure_id\", \"audience_id\": \"audience_id\", \"estimatedTime\": 1," +
+                " \"color\": \"color\", \"description\": \"description\", \"from_session_id\": 5, \"session_id\": null, \"due_date\":" +
+                " \"due_date\", \"type_id\": 3, \"detachFromSession\":true}");
         this.homeworkServiceImpl.updateHomework(1, true, homework, null);
     }
 


### PR DESCRIPTION
## Describe your changes
Un devoir peut être rattaché ou non a une séance. 
Suite à la PR #44 un devoir doit pouvoir changer sa séance ou la définir à null (se détacher de sa séance) 
En base l'id de cette séance est stocké dans la colonne session_ id dans la table des devoirs.

Lorsque l'on appelle l'api on peut mettre à jour la séance lier en fournissant le champ session_id dans le body.
Ce champ n'est pas obligatoire, s'il n'est pas renseigné, il est convenu de ne rien faire.
Malheureuses lorsque l'on récupère le champ session_id du body, qu'il soit null ou non renseigné dans le code on obtient un null. Ce problème empêche de détacher le devoir de sa séance.

Dans ce fix on rajoute un champ boolean optionnel dans le body (detach_from_session). S'il est a vrai et que session_id est nulle et renseignée alors on détache la session en définissant session id à null dans la base.
Si detach_from_session = false ou non défini et que session id = null alors on ne mais pas à jour la session id de l'homework.
Si session_id ! = null alors on met à jour session_id

https://entconf.gdapublic.fr/pages/viewpage.action?spaceKey=MCDT&title=Homework+API
https://entconf.gdapublic.fr/pages/viewpage.action?spaceKey=MCDT&title=Sessions+Homework+API

## Checklist tests
Publier/Dépublier une séance avec des devoirs
Mettre a jour un devoir a un date sans séance.
Mettre a jour un devoir a un date avec séance.

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MCDT-591

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)

