### PR TITLE
docs: inverted back/front links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,8 +3,8 @@
 ## Concept
 The diary module is composed of two part, the backend and the front. They are deployed together in a final jar file to be loaded in the futur in the spring board from open ent ng project.
 
-## [Back end (link)](./front.md)
-## [Front end (link)](./backend.md)
+## [Back end (link)](./backend.md)
+## [Front end (link)](./front.md)
 ## [Installation (link)](./installation.md)
 ## [Rights (link)](./rights.md)
 ## [End of year](./endofyear.md)


### PR DESCRIPTION
## Describe your changes

The links in the documentation were inverted for some reason.
I just put them in the good order.

## Checklist tests

None

## Issue ticket number and link

None

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

Kinda useless for this PR :')