### PR TITLE
fix: #WB2-1756, fix day before issue when creating a session

### DIFF
--- a/src/main/resources/public/ts/model/session.ts
+++ b/src/main/resources/public/ts/model/session.ts
@@ -66,6 +66,12 @@ export class Session {
     }
 
     static formatSqlDataToModel(data: any, structure: Structure) {
+        // FIX #WB2-1756: 
+        // Date from database is returned with time set to "00h00m00s".
+        // By default momentJS will parse and display in local time, so if user is in UTC negative then the date day will be the day before.
+        // Using the utc() function from momentJS will keep the day as the one saved in the database.
+        const formatedDate = moment(data.date).utc().format(FORMAT.formattedDate);
+
         return {
             audience: data.audience,
             teacher: data.teacher,
@@ -78,7 +84,7 @@ export class Session {
             room: data.room,
             color: data.color,
             isPublished: data.is_published,
-            date: DateUtils.getFormattedDate(data.date),
+            date: formatedDate,
             startTime: data.start_time,
             endTime: data.end_time,
             description: data.description,

--- a/src/main/resources/public/ts/model/session.ts
+++ b/src/main/resources/public/ts/model/session.ts
@@ -25,8 +25,8 @@ export class Session {
     title: string;
     color: string = colors[0];
     date: Date = moment().toDate();
-    startTime: any = (moment().set({'hour': '12', 'minute': '00'})).seconds(0).millisecond(0).toDate();
-    endTime: any = (moment().set({'hour': '13', 'minute': '59'})).seconds(0).millisecond(0).toDate();
+    startTime: any = (moment().set({'hour': '08', 'minute': '00'})).seconds(0).millisecond(0).toDate();
+    endTime: any = (moment().set({'hour': '10', 'minute': '00'})).seconds(0).millisecond(0).toDate();
     description: string = '';
     plainTextDescription: string = '';
     annotation: string = '';


### PR DESCRIPTION
## Describe your changes

Date from database is returned with time set to "00h00m00s".
By default momentJS will parse and display in local time, so if user is in UTC negative then the date day will be the day before.
Using the utc() function from momentJS will keep the day as the one saved in the database.

## Checklist tests

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)

