### PR TITLE
fix: sql instantiation in filter

### DIFF
--- a/src/main/java/fr/openent/diary/security/workflow/HomeworkManage.java
+++ b/src/main/java/fr/openent/diary/security/workflow/HomeworkManage.java
@@ -1,6 +1,7 @@
 package fr.openent.diary.security.workflow;
 
 import fr.openent.diary.Diary;
+import fr.openent.diary.db.DB;
 import fr.openent.diary.db.DBService;
 import fr.openent.diary.helper.FutureHelper;
 import fr.openent.diary.security.WorkflowUtils;
@@ -59,7 +60,9 @@ public class HomeworkManage extends DBService implements ResourcesProvider {
         String query = " SELECT teacher_id" +
                 " FROM " + Diary.DIARY_SCHEMA + ".homework" +
                 " WHERE id = ? ";
-
+        if (sql == null) {
+            this.sql = DB.getInstance().sql();
+        }
         sql.prepared(query, new JsonArray(Collections.singletonList(homeworkId)),
                 SqlResult.validUniqueResultHandler(FutureHelper.handlerJsonObject(promise)));
         return promise.future();

--- a/src/main/java/fr/openent/diary/security/workflow/SessionManage.java
+++ b/src/main/java/fr/openent/diary/security/workflow/SessionManage.java
@@ -1,6 +1,7 @@
 package fr.openent.diary.security.workflow;
 
 import fr.openent.diary.Diary;
+import fr.openent.diary.db.DB;
 import fr.openent.diary.db.DBService;
 import fr.openent.diary.helper.FutureHelper;
 import fr.openent.diary.security.WorkflowUtils;
@@ -59,6 +60,9 @@ public class SessionManage extends DBService implements ResourcesProvider {
         String query = " SELECT teacher_id" +
                 " FROM " + Diary.DIARY_SCHEMA + ".session" +
                 " WHERE id = ? ";
+        if (sql == null) {
+            this.sql = DB.getInstance().sql();
+        }
         sql.prepared(query, new JsonArray(Collections.singletonList(sessionId)),
                 SqlResult.validUniqueResultHandler(FutureHelper.handlerJsonObject(promise)));
         return promise.future();


### PR DESCRIPTION
## Describe your changes

Force sql driver instantiation in filters because security filters are instantiated before global database drivers of the verticle are instantiated. 

## Checklist tests

Manual and debug dev tests on recette-release

## Issue ticket number and link

https://edifice-community.atlassian.net/browse/PEDAGO-3778

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

